### PR TITLE
Fix bug preventing module from loading

### DIFF
--- a/BrainParcellation.py
+++ b/BrainParcellation.py
@@ -19,7 +19,7 @@ class BrainParcellation(ScriptedLoadableModule):
     super().__init__(parent)
     self.parent.title = 'Brain Parcellation'
     self.parent.categories = ['Segmentation']
-    self.parent.dependencies = ['']
+    self.parent.dependencies = []
     self.parent.contributors = [
       "Fernando Perez-Garcia (University College London and King's College London)",
     ]


### PR DESCRIPTION
Before this change, when trying to enter the "Brain Parcellation" module in 3D Slicer, the module title was in red font and the description would read "This module is not loaded."  In the Python Console, there would be an error message saying "[Qt] When loading module  "BrainParcellation" , the dependency "" failed to be loaded."

To fix this, I simply removed the empty apostrophes and the module was able to load. 